### PR TITLE
Issue #5 値オブジェクト`ISymbolId`を利用した実装へ変更

### DIFF
--- a/documentationAI/application/documentation_service.py
+++ b/documentationAI/application/documentation_service.py
@@ -35,17 +35,16 @@ class DocumentationService:
         resolved = topological_sort(dependencies_map)
 
         # 解決された順番にしたがってドキュメンテーション生成を行う。
-        for symbol_id_str in resolved:
-            required_symbol_id_str_list = dependencies_map[symbol_id_str]   # TODO: 解析対象のファイルで「存在しないモジュールをインポートしている」場合，ここでエラーになる。なぜなら，dependencies_mapは存在するモジュールのシンボル情報を解析して保存した辞書だから。
+        for symbol_id in resolved:
+            # TODO: 解析対象のファイルで「存在しないモジュールをインポートしている」場合，ここでエラーになる。なぜなら，dependencies_mapは存在するモジュールのシンボル情報を解析して保存した辞書だから。
+            required_symbol_ids = dependencies_map[symbol_id]
             # 1. シンボルのソース定義を取得
-            symbol_id = self.helper.parse_symbol_id_str(symbol_id_str)
             print(f"Generating document for {symbol_id.stringify()}...")
             symbol_def = self.helper.get_symbol_def(symbol_id, package_root_dir)
 
             # 2. 依存先シンボルのドキュメントを取得
             required_symbol_docs: list[Document] = []
-            for required_symbol_id_str in required_symbol_id_str_list:
-                required_symbol_id = self.helper.parse_symbol_id_str(required_symbol_id_str)
+            for required_symbol_id in required_symbol_ids:
                 required_symbol_doc = self.document_repository.get_by_symbol_id(required_symbol_id)
                 if required_symbol_doc: # TODO: 見つからなければ何をするのか，具体的に考えておくこと
                     required_symbol_docs.append(required_symbol_doc)
@@ -66,7 +65,7 @@ class DocumentationService:
             # TODO: 例外処理をもっと丁寧に書く
             except InvalidRequestError as e:
                 print(e)
-                print(f"An error occurred and skipped generating documentation for {symbol_id_str}.")
+                print(f"An error occurred and skipped generating documentation for {symbol_id.stringify()}.")
                 self.document_repository.save(Document(
                     symbol_id = symbol_id,
                     content = "",

--- a/documentationAI/domain/implementation/python/package_analyzer.py
+++ b/documentationAI/domain/implementation/python/package_analyzer.py
@@ -13,19 +13,17 @@ class PythonPackageAnalyzer(IPackageAnalyzer):
         module_analyzer: PythonModuleAnalyzer,
         helper: IAnalyzerHelper
     ):
-        # super().__init__(module_analyzer, helper)
         self.module_analyzer = module_analyzer
         self.helper = helper
     
 
     # PythonDependenciesAnalyzerを使って，root_dir以下のファイルを解析し，依存関係を取得
-    def generate_dag(
+    def generate_dag(    # type: ignore `ISymbolId`と`PythonSymbolId`の互換性に関する警告を無視
         self,
         package_root_dir: str,
         package_name: str
-    ) -> Dict[str, list[str]]:
+    ) -> Dict[PythonSymbolId, list[PythonSymbolId]]:
 
-        # NOTE: pylanceの型チェック`ISymbolInfo`と`PythonSymbolInfo`の問題で，`ISymbolInfo`を選択した
         overall_dependencies: Dict[str, Dict[str, list[PythonSymbolId]]] = {}
         # ルートディレクトリ以下の全pythonソースに対して処理を行う
         for dirpath, _, filenames in os.walk(package_root_dir):
@@ -37,17 +35,19 @@ class PythonPackageAnalyzer(IPackageAnalyzer):
                     overall_dependencies[namespace] = symbols_dependencies  # type: ignore
         
         # 依存関係をDAGに変換
-        dag: Dict[str, list[str]] = {}
+        # dag: Dict[str, list[str]] = {}
+        dag: Dict[PythonSymbolId, list[PythonSymbolId]] = {}
         for namespace, dependencies in overall_dependencies.items():
-            for symbol_name, dependent_symbol_infos in dependencies.items():
-                symbol_info_str = PythonSymbolId(namespace, symbol_name).stringify()
-                dag[symbol_info_str] = []
-                for dependent_symbol_info in dependent_symbol_infos:
+            for symbol_name, required_symbol_ids in dependencies.items():
+                # symbol_info_str = PythonSymbolId(namespace, symbol_name).stringify()
+                symbol_id = PythonSymbolId(namespace, symbol_name)
+                dag[symbol_id] = []
+                for required_symbol_id in required_symbol_ids:
                     # 依存先の情報の中に，symbol_name == '*'のものがある場合，当該ファイル内のすべてのトップレベルシンボルをインポートすることを意味する
-                    if dependent_symbol_info.symbol_name == '*':
-                        for each_symbol_name in overall_dependencies[dependent_symbol_info.namespace].keys():
-                            dag[symbol_info_str].append(PythonSymbolId(dependent_symbol_info.namespace, each_symbol_name).stringify())
+                    if required_symbol_id.symbol_name == '*':
+                        for each_symbol_name in overall_dependencies[required_symbol_id.namespace].keys():
+                            dag[symbol_id].append(PythonSymbolId(required_symbol_id.namespace, each_symbol_name))
                     else:
-                        dag[symbol_info_str].append(dependent_symbol_info.stringify())
+                        dag[symbol_id].append(required_symbol_id)
                     
         return dag

--- a/documentationAI/domain/implementation/python/symbol.py
+++ b/documentationAI/domain/implementation/python/symbol.py
@@ -22,5 +22,8 @@ class PythonSymbolId(ISymbolId):
         else:
             return False
     
+    def __hash__(self) -> int:
+        return hash(self.stringify())
+    
     def __str__(self) -> str:
         return f"PythonSymbolInfo(namespace={self.namespace}, symbol_name={self.symbol_name})"

--- a/documentationAI/domain/models/symbol.py
+++ b/documentationAI/domain/models/symbol.py
@@ -21,6 +21,10 @@ class ISymbolId(abc.ABC):
         pass
 
     @abc.abstractmethod
+    def __hash__(self) -> int:
+        pass
+
+    @abc.abstractmethod
     def __str__(self) -> str:
         pass
 

--- a/documentationAI/domain/services/analyzer.py
+++ b/documentationAI/domain/services/analyzer.py
@@ -40,5 +40,5 @@ class IModuleAnalyzer(abc.ABC):
 class IPackageAnalyzer(abc.ABC):
 
     @abc.abstractmethod
-    def generate_dag(self, package_root_dir: str, package_name: str) -> Dict[str, list[str]]:
+    def generate_dag(self, package_root_dir: str, package_name: str) -> Dict[ISymbolId, list[ISymbolId]]:
         pass

--- a/documentationAI/utils/topological_sort.py
+++ b/documentationAI/utils/topological_sort.py
@@ -1,5 +1,8 @@
 from graphlib import TopologicalSorter
+from typing import TypeVar
 
-def topological_sort(dag: dict[str, list[str]]) -> list[str]:
+T = TypeVar('T')
+
+def topological_sort(dag: dict[T, list[T]]) -> list[T]:
     ts = TopologicalSorter(dag)
     return list(ts.static_order())


### PR DESCRIPTION
### 概要
シンボルの同一性を示すための`ISymbolId`という値オブジェクトがあるのに，`ISymbolId.stringify()`した結果の`str`を使って処理を行っている部分があった。それを`ISymbolId`を用いてより型安全な実装へと変更した。

### 変更内容
**注意**: `IModuleAnalyzer`は変更していない。  
`IModuleAnalyzer`については，従来通り`ISymbolInfo`と`str`の混ざった形式を維持している。なぜならば，`import namespace`や`from <namespace> import *`など，全シンボルをインポートする場合にも対応可能である必要があるからだ。(その対応は，`IPackageAnalyzer`内部で行う)
- `ISymbolInfo`および実装クラスに，`__hash__()`メソッドを追加:  
  ユーザー定義のクラスを辞書のキーに使うためには，`hashable`であることが必要である[^HASHABLE]。そこで`__hash__()`メソッドを実装した。具体的には，`self.stringify()`した結果を組み込み関数`hash()`に入れて返す形をとった。
[^HASHABLE]: 参考記事: https://www.yoheim.net/blog.php?q=20171001
- `IPackageAnalyzer`および実装クラスの返り値の型変更:  
  `ISymbolId`を文字列化した`str`を格納する実装から，`ISymbolId`をそのまま格納する実装へ変更
- `IPackageAnalyzer`の変更に伴う`DocumentationService`の実装の変更
- トポロジカルソート関数の一部修正:  
  引数`dag`として`dict[str, list[str]]`のみを受け付ける実装から，型変数を利用して`dag: dict[T, list[T]]`を受け付けるよう変更

### テスト
自動テストは作成できていないが，[`DocumentationService`](./documentationAI/application/documentation_service.py)のデバッグ用コードを利用し基本的な動作確認を行った。

### 影響
影響範囲はすべてカバーしているはずである。

### その他情報

### 関連issue
#5 