### PR TITLE
Issue #9 ドキュメント生成を並列処理化

### DIFF
--- a/documentationAI/application/documentation_service.py
+++ b/documentationAI/application/documentation_service.py
@@ -47,7 +47,7 @@ class DocumentationService:
         self._reversed_dependencies_map = self.package_analyzer.generate_reversed_dag_from_dag(self._dependencies_map)
 
         # progressは現状"pending", "processing", "fulfilled", "rejected"の4つの値をとることにする
-        self.progress_map: Dict[ISymbolId, str] = {symbol_id: "pending" for symbol_id in self._dependencies_map.keys()}
+        self._progress_map: Dict[ISymbolId, str] = {symbol_id: "pending" for symbol_id in self._dependencies_map.keys()}
 
         # 解決された順番にしたがってドキュメンテーション生成を行う。
         initial_process_symbol_ids: list[ISymbolId] = []
@@ -124,7 +124,7 @@ class DocumentationService:
     # シンボルのドキュメント生成が可能かどうかを判定するprivateメソッド。依存先シンボルのドキュメントがすべて生成済み（または依存先がない）ことを確認する
     def _can_be_processed(self, symbol_id: ISymbolId) -> bool:
         for dependency in self._dependencies_map[symbol_id]:
-            if self.progress_map[dependency] != "fulfilled":
+            if self._progress_map[dependency] != "fulfilled":
                 return False
         return True
     
@@ -133,10 +133,10 @@ class DocumentationService:
     # 受け取った`symbol_id`のドキュメントが未生成であることをチェックしてから，ドキュメントを生成
     # さらに生成後には，`symbol_id`に依存しているシンボルのうち，ドキュメント生成が可能な状態のものを再帰的に処理する。
     async def _exec_documentation_chain(self, symbol_id: ISymbolId):
-        if self.progress_map[symbol_id] == "pending":
-            self.progress_map[symbol_id] = "processing"
+        if self._progress_map[symbol_id] == "pending":
+            self._progress_map[symbol_id] = "processing"
             await self._documentation(symbol_id)
-            self.progress_map[symbol_id] = "fulfilled"
+            self._progress_map[symbol_id] = "fulfilled"
 
             symbols_to_be_processed: list[ISymbolId] = []
             for each_reference in self._reversed_dependencies_map[symbol_id]:

--- a/documentationAI/container.py
+++ b/documentationAI/container.py
@@ -57,7 +57,7 @@ class Container(containers.DeclarativeContainer):
         DocumentationPromptGenerator,
     )
 
-    documentation_service = providers.Singleton(
+    documentation_service = providers.Factory(
         DocumentationService,
         package_analyzer = package_analyzer,
         document_repository = document_repository,

--- a/documentationAI/domain/implementation/python/package_analyzer.py
+++ b/documentationAI/domain/implementation/python/package_analyzer.py
@@ -51,3 +51,13 @@ class PythonPackageAnalyzer(IPackageAnalyzer):
                         dag[symbol_id].append(required_symbol_id)
                     
         return dag
+
+    
+    def generate_reversed_dag_from_dag(self, dag: Dict[PythonSymbolId, list[PythonSymbolId]]) -> Dict[PythonSymbolId, list[PythonSymbolId]]:    # type: ignore
+        reversed_dag: Dict[PythonSymbolId, list[PythonSymbolId]] = {node: [] for node in dag}
+
+        for node, dependencies in dag.items():
+            for dependency in dependencies:
+                reversed_dag[dependency].append(node)
+        
+        return reversed_dag

--- a/documentationAI/domain/services/analyzer.py
+++ b/documentationAI/domain/services/analyzer.py
@@ -42,3 +42,7 @@ class IPackageAnalyzer(abc.ABC):
     @abc.abstractmethod
     def generate_dag(self, package_root_dir: str, package_name: str) -> Dict[ISymbolId, list[ISymbolId]]:
         pass
+    
+    @abc.abstractmethod
+    def generate_reversed_dag_from_dag(self, dag: Dict[ISymbolId, list[ISymbolId]]) -> Dict[ISymbolId, list[ISymbolId]]:
+        pass

--- a/documentationAI/interfaces/adapter/handlers.py
+++ b/documentationAI/interfaces/adapter/handlers.py
@@ -45,12 +45,9 @@ def documentation(params: list[str]) -> None:
                 "db_path": os.path.join(project_root_dir, "docai_db.sqlite")
             }
         })
-        documentation_generator_service = container.documentation_service()
+        documentation_service = container.documentation_service()
 
-        async def _generate():
-            await documentation_generator_service.generate_package_documentation(project_root_dir, package_root_dir, package_name)
-        
-        asyncio.run(_generate())
+        asyncio.run(documentation_service.generate_package_documentation(project_root_dir, package_root_dir, package_name))
         break
     
 

--- a/documentationAI/interfaces/adapter/handlers.py
+++ b/documentationAI/interfaces/adapter/handlers.py
@@ -1,6 +1,7 @@
 # TODO: ハンドラを定義して，辞書`routes`に名前付きで登録してください。
 # TODO: 現状，ハンドラはパラメータとして引数`params: list[str]`として受け取っていますが，変更を検討しても良いかもしれません。
 import os
+import asyncio
 from typing import Dict, Callable
 
 
@@ -45,7 +46,11 @@ def documentation(params: list[str]) -> None:
             }
         })
         documentation_generator_service = container.documentation_service()
-        documentation_generator_service.generate_package_documentation(project_root_dir, package_root_dir, package_name)
+
+        async def _generate():
+            await documentation_generator_service.generate_package_documentation(project_root_dir, package_root_dir, package_name)
+        
+        asyncio.run(_generate())
         break
     
 


### PR DESCRIPTION
### 概要
もとの仕様ではドキュメント生成を，愚直にトポロジカルソートした順番にしたがって一件ずつ行っていた。これをより高速に行えるよう，並列化を実装。技術的には`asyncio`ライブラリの`asyncio.to_thread()`等を利用して実現。並列処理の具体的なフローは[issue](https://github.com/HLHHS11/Documentation-AI/issues/9#issuecomment-1723466217)を参照。

### 変更内容
- `asyncio.to_thread()`を利用した並列化・非同期化:  
  実際にAPIにリクエストを投げる部分をマルチスレッド化し，その処理結果を取得する`await`が使えるよう，`DocumentationService.generate_package_documentation()`に`async`をつけた。
- ローカル変数をインスタンスのプロパティとして扱う:  
  処理が複雑に入り組むので，ローカル変数をプライベートプロパティとして扱い，処理を切り分けたプライベートメソッドの間で共有できるようにした。[^AS_PROP]
[^AS_PROP]: `generate_package_documentation()`メソッド内部でローカル専用関数を定義して利用する方法も考えたが，著しく可読性が落ちるためプライベートメソッドとして切り分け，必要な変数はプロパティ化することで共有することを選択した。
- `asyncio.run()`を用いて非同期処理を呼び出す:  
  コマンドのハンドラ関数`documentation`内部で，単に`documentation_service.generate_package_documentation()`を呼び出しても，これは`async`メソッドなのでエラーが出る。これを正しく呼び出すため，`asyncio.run()`を使用するよう変更
- その他軽微なリファクタリング・命名変更など

### テスト
自動テストは作成できていないが，[`DocumentationService`](./documentationAI/application/documentation_service.py)のファイル内のデバッグ用コードで基本的な動作確認を行った。

### 影響
### その他情報
- ドキュメント生成処理が非常に高速化したため，軽い気持ちでデバッグを行ってしまうとAPIの多額請求が発生する可能性がある。コメントアウトした状態でpushした，デバッグ用コード(`response_text = f"{self._counter}テストレスポンス。これはテストです。"`という部分)を適宜利用すべし。
- 上記のように，APIとの通信部分のモックとの差し替えが非常に面倒である。**今後，これらのAPI周辺の処理もサービスとして切り出す必要があるだろう**
### 関連issue
#9 