### PR TITLE
Issue #12 `DocumentRepository`のSQLite実装と`Document`の仕様改善

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,3 @@ temp_note.md
 
 # db file for test
 test/test_db.sqlite
-
-# db file for `DocumentationService` test
-test/test_documentation_service_db.sqlite

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@ upload.zip
 .env
 
 temp_note.md
+
+# db file for test
+test/test_db.sqlite

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@ temp_note.md
 
 # db file for test
 test/test_db.sqlite
+
+# db file for `DocumentationService` test
+test/test_documentation_service_db.sqlite

--- a/documentationAI/application/documentation_service.py
+++ b/documentationAI/application/documentation_service.py
@@ -111,7 +111,7 @@ class DocumentationService:
 
         generated_document = Document(  # TODO: よしなに生成する。これ専用にファクトリメソッドを作ってもいい
             symbol_id = symbol_id,
-            # dependencies = required_symbol_id_list,   # TODO: 現時点では`required_symbol_id_list`を直接は利用していないので，コメントアウト
+            dependencies = required_symbol_ids,
             content = response_text,
             succeeded = True
         )

--- a/documentationAI/application/documentation_service.py
+++ b/documentationAI/application/documentation_service.py
@@ -157,21 +157,24 @@ if __name__ == "__main__":
         from documentationAI.domain.implementation.python.module_analyzer import PythonModuleAnalyzer
         from documentationAI.domain.implementation.python.helper import PythonAnalyzerHelper
         from documentationAI.domain.implementation.python.symbol import PythonSymbolId
-        from documentationAI.interfaces.repository.document_repository_impl.in_memory import InMemoryDocumentRepositoryImpl
+        from documentationAI.interfaces.repository.document_repository_impl.sqlite import SQLiteDocumentRepositoryImpl
 
 
         helper = PythonAnalyzerHelper()
         module_analyzer = PythonModuleAnalyzer(helper)
         package_analyzer = PythonPackageAnalyzer(module_analyzer, helper)
         prompt_generator = DocumentationPromptGenerator()
-        class MockDocumentRepository(InMemoryDocumentRepositoryImpl):
+        class MockDocumentRepository(SQLiteDocumentRepositoryImpl):
             def __init__(self):
-                super().__init__()
+                super().__init__(
+                    sqlite_db_path = os.path.join(os.path.dirname(__file__), "../../", "test/test_documentation_service_db.sqlite"),
+                    helper = PythonAnalyzerHelper()
+                )
             def save(self, document: Document) -> None:
                 super().save(document)
                 print("\n========saved========")
                 print(document.get_content())
-            def get_by_symbol_id(self, symbol_id: PythonSymbolId) -> Document:  # type: ignore
+            def get_by_symbol_id(self, symbol_id: PythonSymbolId) -> Document|None:  # type: ignore
                 return super().get_by_symbol_id(symbol_id)
         
         document_repository = MockDocumentRepository()

--- a/documentationAI/application/documentation_service.py
+++ b/documentationAI/application/documentation_service.py
@@ -94,22 +94,13 @@ class DocumentationService:
         # TODO: 例外処理をもっと丁寧に書く
         except InvalidRequestError as e:
             print(e)
-            # トークン数の問題でエラーが発生したので，GPT-3.5 16k contextを利用して再度トライする旨を表示
-            print(f"A token limit error occurred for {symbol_id.stringify()}, so we will try again with GPT-3.5 16k context.")
-            # GPT-3.5 16k contextを使用して再度トライ
-            try:
-                chat = ChatOpenAI(temperature = 0.25, model = "gpt-3.5-turbo-16k")
-                response = await asyncio.to_thread(chat, messages)
-                print("Successfully generated documentation with GPT-3.5 16k context.")
-            except InvalidRequestError as e:
-                print(f"An error occurred and skipped generating documentation for {symbol_id.stringify()}.")
-                self.document_repository.save(Document(
-                    symbol_id = symbol_id,
-                    dependencies = required_symbol_ids,
-                    content = "",
-                    succeeded = False
-                ))
-                return
+            print(f"An error occurred and skipped generating documentation for {symbol_id.stringify()}.")
+            self.document_repository.save(Document(
+                symbol_id = symbol_id,
+                content = "",
+                succeeded = False
+            ))
+            return
         
         response_text = response.content
 
@@ -166,24 +157,21 @@ if __name__ == "__main__":
         from documentationAI.domain.implementation.python.module_analyzer import PythonModuleAnalyzer
         from documentationAI.domain.implementation.python.helper import PythonAnalyzerHelper
         from documentationAI.domain.implementation.python.symbol import PythonSymbolId
-        from documentationAI.interfaces.repository.document_repository_impl.sqlite import SQLiteDocumentRepositoryImpl
+        from documentationAI.interfaces.repository.document_repository_impl.in_memory import InMemoryDocumentRepositoryImpl
 
 
         helper = PythonAnalyzerHelper()
         module_analyzer = PythonModuleAnalyzer(helper)
         package_analyzer = PythonPackageAnalyzer(module_analyzer, helper)
         prompt_generator = DocumentationPromptGenerator()
-        class MockDocumentRepository(SQLiteDocumentRepositoryImpl):
+        class MockDocumentRepository(InMemoryDocumentRepositoryImpl):
             def __init__(self):
-                super().__init__(
-                    sqlite_db_path = os.path.join(os.path.dirname(__file__), "../../", "test/test_documentation_service_db.sqlite"),
-                    helper = PythonAnalyzerHelper()
-                )
+                super().__init__()
             def save(self, document: Document) -> None:
                 super().save(document)
                 print("\n========saved========")
                 print(document.get_content())
-            def get_by_symbol_id(self, symbol_id: PythonSymbolId) -> Document|None:  # type: ignore
+            def get_by_symbol_id(self, symbol_id: PythonSymbolId) -> Document:  # type: ignore
                 return super().get_by_symbol_id(symbol_id)
         
         document_repository = MockDocumentRepository()

--- a/documentationAI/application/documentation_service.py
+++ b/documentationAI/application/documentation_service.py
@@ -94,13 +94,22 @@ class DocumentationService:
         # TODO: 例外処理をもっと丁寧に書く
         except InvalidRequestError as e:
             print(e)
-            print(f"An error occurred and skipped generating documentation for {symbol_id.stringify()}.")
-            self.document_repository.save(Document(
-                symbol_id = symbol_id,
-                content = "",
-                succeeded = False
-            ))
-            return
+            # トークン数の問題でエラーが発生したので，GPT-3.5 16k contextを利用して再度トライする旨を表示
+            print(f"A token limit error occurred for {symbol_id.stringify()}, so we will try again with GPT-3.5 16k context.")
+            # GPT-3.5 16k contextを使用して再度トライ
+            try:
+                chat = ChatOpenAI(temperature = 0.25, model = "gpt-3.5-turbo-16k")
+                response = await asyncio.to_thread(chat, messages)
+                print("Successfully generated documentation with GPT-3.5 16k context.")
+            except InvalidRequestError as e:
+                print(f"An error occurred and skipped generating documentation for {symbol_id.stringify()}.")
+                self.document_repository.save(Document(
+                    symbol_id = symbol_id,
+                    dependencies = required_symbol_ids,
+                    content = "",
+                    succeeded = False
+                ))
+                return
         
         response_text = response.content
 
@@ -157,21 +166,24 @@ if __name__ == "__main__":
         from documentationAI.domain.implementation.python.module_analyzer import PythonModuleAnalyzer
         from documentationAI.domain.implementation.python.helper import PythonAnalyzerHelper
         from documentationAI.domain.implementation.python.symbol import PythonSymbolId
-        from documentationAI.interfaces.repository.document_repository_impl.in_memory import InMemoryDocumentRepositoryImpl
+        from documentationAI.interfaces.repository.document_repository_impl.sqlite import SQLiteDocumentRepositoryImpl
 
 
         helper = PythonAnalyzerHelper()
         module_analyzer = PythonModuleAnalyzer(helper)
         package_analyzer = PythonPackageAnalyzer(module_analyzer, helper)
         prompt_generator = DocumentationPromptGenerator()
-        class MockDocumentRepository(InMemoryDocumentRepositoryImpl):
+        class MockDocumentRepository(SQLiteDocumentRepositoryImpl):
             def __init__(self):
-                super().__init__()
+                super().__init__(
+                    sqlite_db_path = os.path.join(os.path.dirname(__file__), "../../", "test/test_documentation_service_db.sqlite"),
+                    helper = PythonAnalyzerHelper()
+                )
             def save(self, document: Document) -> None:
                 super().save(document)
                 print("\n========saved========")
                 print(document.get_content())
-            def get_by_symbol_id(self, symbol_id: PythonSymbolId) -> Document:  # type: ignore
+            def get_by_symbol_id(self, symbol_id: PythonSymbolId) -> Document|None:  # type: ignore
                 return super().get_by_symbol_id(symbol_id)
         
         document_repository = MockDocumentRepository()

--- a/documentationAI/container.py
+++ b/documentationAI/container.py
@@ -45,14 +45,14 @@ class Container(containers.DeclarativeContainer):
     )
 
     # document_repository = providers.Singleton(
-    #     SQLiteDocumentRepositoryImpl,
-    #     sqlite_db_path = config.sqlite.db_path
+    #     InMemoryDocumentRepositoryImpl,
     # )
 
     document_repository = providers.Singleton(
-        InMemoryDocumentRepositoryImpl,
+        SQLiteDocumentRepositoryImpl,
+        sqlite_db_path = config.sqlite.db_path,
+        helper = helper
     )
-
     prompt_generator = providers.Factory(
         DocumentationPromptGenerator,
     )

--- a/documentationAI/container.py
+++ b/documentationAI/container.py
@@ -45,14 +45,14 @@ class Container(containers.DeclarativeContainer):
     )
 
     # document_repository = providers.Singleton(
-    #     InMemoryDocumentRepositoryImpl,
+    #     SQLiteDocumentRepositoryImpl,
+    #     sqlite_db_path = config.sqlite.db_path
     # )
 
     document_repository = providers.Singleton(
-        SQLiteDocumentRepositoryImpl,
-        sqlite_db_path = config.sqlite.db_path,
-        helper = helper
+        InMemoryDocumentRepositoryImpl,
     )
+
     prompt_generator = providers.Factory(
         DocumentationPromptGenerator,
     )

--- a/documentationAI/domain/models/document.py
+++ b/documentationAI/domain/models/document.py
@@ -8,12 +8,12 @@ class Document:
     def __init__(
         self,
         symbol_id: ISymbolId,
-        # dependencies: list[ISymbolId],
+        dependencies: list[ISymbolId],
         content: str,
         succeeded: bool,
     ):
         self._symbol_id = symbol_id
-        # self._dependencies = dependencies
+        self._dependencies = dependencies
         self._content = content
         self._succeeded = succeeded
 
@@ -25,3 +25,6 @@ class Document:
 
     def is_succeeded(self) -> bool:
         return self._succeeded
+    
+    def get_dependencies(self) -> list[ISymbolId]:
+        return self._dependencies

--- a/documentationAI/domain/repositories/interfaces.py
+++ b/documentationAI/domain/repositories/interfaces.py
@@ -8,7 +8,7 @@ from documentationAI.domain.models.symbol import ISymbolId
 class IDocumentRepository(abc.ABC):
 
     @abc.abstractmethod
-    def get_by_symbol_id(self, symbol_id: ISymbolId) -> Document:
+    def get_by_symbol_id(self, symbol_id: ISymbolId) -> Document|None:
         pass
 
     @abc.abstractmethod

--- a/documentationAI/interfaces/adapter/handlers.py
+++ b/documentationAI/interfaces/adapter/handlers.py
@@ -35,12 +35,7 @@ def documentation(params: list[str]) -> None:
         
         # NOTE: トップレベルでインポートすると循環参照になるので，関数内で遅延インポートする。
         from documentationAI.container import container
-        container.config.from_dict({    # TODO: ここでifもつけずに設定するのはかなり強引。後で修正すること。
-            "local_directory": {
-                "project_root_dir": project_root_dir,
-                "package_root_dir": package_root_dir,
-                "package_name": package_name
-            },
+        container.config.from_dict({
             "sqlite": {
                 "db_path": os.path.join(project_root_dir, "docai_db.sqlite")
             }

--- a/documentationAI/interfaces/adapter/handlers.py
+++ b/documentationAI/interfaces/adapter/handlers.py
@@ -35,7 +35,12 @@ def documentation(params: list[str]) -> None:
         
         # NOTE: トップレベルでインポートすると循環参照になるので，関数内で遅延インポートする。
         from documentationAI.container import container
-        container.config.from_dict({
+        container.config.from_dict({    # TODO: ここでifもつけずに設定するのはかなり強引。後で修正すること。
+            "local_directory": {
+                "project_root_dir": project_root_dir,
+                "package_root_dir": package_root_dir,
+                "package_name": package_name
+            },
             "sqlite": {
                 "db_path": os.path.join(project_root_dir, "docai_db.sqlite")
             }

--- a/documentationAI/interfaces/repository/document_repository_impl/in_memory.py
+++ b/documentationAI/interfaces/repository/document_repository_impl/in_memory.py
@@ -10,8 +10,11 @@ class InMemoryDocumentRepositoryImpl(IDocumentRepository):
     def __init__(self):
         self._documents: Dict[str, Document] = {}
     
-    def get_by_symbol_id(self, symbol_id: ISymbolId) -> Document:
-        return self._documents[symbol_id.stringify()]
+    def get_by_symbol_id(self, symbol_id: ISymbolId) -> Document|None:
+        try:
+            return self._documents[symbol_id.stringify()]
+        except KeyError:
+            return None
     
     def save(self, document: Document) -> None:
         self._documents[document.get_symbol_id().stringify()] = document

--- a/documentationAI/interfaces/repository/document_repository_impl/in_memory.py
+++ b/documentationAI/interfaces/repository/document_repository_impl/in_memory.py
@@ -25,6 +25,7 @@ if __name__ == "__main__":
 
         document1 = Document(
             symbol_id = PythonSymbolId("test.namespace.hoge", "test_symbol_name"),
+            dependencies = [],
             content = "test_document_content",
             succeeded = True
         )

--- a/documentationAI/interfaces/repository/document_repository_impl/sqlite.py
+++ b/documentationAI/interfaces/repository/document_repository_impl/sqlite.py
@@ -1,11 +1,167 @@
-from requests import Session
 import sqlite3
-
+from documentationAI.domain.models.document import Document
+from documentationAI.domain.models.symbol import ISymbolId
 from documentationAI.domain.repositories.interfaces import IDocumentRepository
+from documentationAI.domain.services.analyzer import IAnalyzerHelper
 
 
 class SQLiteDocumentRepositoryImpl(IDocumentRepository):
 
-    def __init__(self, sqlite_db_path: str):
-        self.connection = sqlite3.connect(sqlite_db_path)
+    def __init__(self, sqlite_db_path: str, helper: IAnalyzerHelper):
+        self.helper = helper
 
+        self.conn = sqlite3.connect(sqlite_db_path)
+        cursor = self.conn.cursor()
+
+        cursor.execute("""
+CREATE TABLE IF NOT EXISTS versions (
+    version INTEGER,
+    created_at TEXT,
+    UNIQUE(version)
+);
+""")
+        cursor.execute("""
+CREATE TABLE IF NOT EXISTS documents (
+    symbol_id VARCHAR(255),
+    exec_version INTEGER,
+    content TEXT,
+    succeeded INTEGER,
+    PRIMARY KEY (symbol_id, exec_version),
+    FOREIGN KEY (exec_version) REFERENCES versions(version)   
+);
+""")
+        cursor.execute("""
+CREATE TABLE IF NOT EXISTS symbol_dependencies (
+    symbol_id VARCHAR(255),
+    exec_version INTEGER,
+    dependency_symbol_id VARCHAR(255),
+    PRIMARY KEY (symbol_id, exec_version, dependency_symbol_id),
+    FOREIGN KEY (symbol_id, exec_version) REFERENCES documents(symbol_id, exec_version)
+);
+""")
+        # バージョンをインクリメントする
+        new_version = self._get_current_version() + 1
+        cursor.execute("""
+INSERT INTO versions (version, created_at) VALUES (?, datetime('now', 'localtime'));
+""", (new_version,))
+        
+    
+    def get_by_symbol_id(self, symbol_id: ISymbolId) -> Document|None:
+        cursor = self.conn.cursor()
+        exec_version = self._get_current_version()
+        # Documentの基本情報を取得するクエリ
+        cursor.execute("""
+SELECT  d.content, d.succeeded, v.created_at
+    FROM documents AS d
+    JOIN versions AS v ON d.exec_version = v.version
+    WHERE d.symbol_id = ? AND d.exec_version = ?;
+""", (symbol_id.stringify(), exec_version))
+        
+        result = cursor.fetchone()
+
+        if result:
+            content, succeeded, _ = result
+            # Documentのシンボルの依存関係を取得するクエリ
+            cursor.execute("""
+SELECT dependency_symbol_id
+    FROM symbol_dependencies
+    WHERE symbol_id = ? AND exec_version = ?;
+""", (symbol_id.stringify(), exec_version))
+            dependencies: list[ISymbolId] = []
+            for dependency_symbol_id_str in cursor.fetchall():
+                dependencies.append(self.helper.parse_symbol_id_str(dependency_symbol_id_str[0]))
+            
+            return Document(
+                symbol_id = symbol_id,
+                dependencies = dependencies,
+                content = str(content),
+                succeeded = bool(succeeded),
+            )
+        else:
+            return None
+    
+
+    def save(self, document: Document) -> None:
+        cursor = self.conn.cursor()
+        exec_version = self._get_current_version()
+        
+        try:            
+            cursor.execute("""
+INSERT INTO documents
+    (symbol_id, exec_version, content, succeeded)
+    VALUES (?, ?, ?, ?);
+""", (document.get_symbol_id().stringify(), exec_version, document.get_content(), int(document.is_succeeded())))
+            
+            for dependency_symbol_id in document.get_dependencies():
+                cursor.execute("""
+INSERT INTO symbol_dependencies
+    (symbol_id, exec_version, dependency_symbol_id)
+    VALUES (?, ?, ?);
+""", (document.get_symbol_id().stringify(), exec_version, dependency_symbol_id.stringify()))
+                
+                self.conn.commit()
+        except Exception as e:
+            self.conn.rollback()
+            raise e
+    
+
+    def close(self) -> None:
+        self.conn.close()
+
+
+    def _get_current_version(self) -> int:
+        cursor = self.conn.cursor()
+        cursor.execute("""
+    SELECT MAX(version) FROM versions;
+""")
+        result = cursor.fetchone()
+        if result:
+            if result[0]:
+                return int(result[0])
+            else:
+                return 0
+        else:
+            return 0
+
+
+if __name__ == "__main__":
+    def debug():
+        import os
+        from documentationAI.domain.implementation.python.helper import PythonAnalyzerHelper
+        from documentationAI.domain.implementation.python.symbol import PythonSymbolId
+        # 現在のディレクトリより４階層上
+        document_repository = SQLiteDocumentRepositoryImpl(
+            sqlite_db_path = os.path.join(os.path.dirname(__file__), "../../../..", "test/test_db.sqlite"),
+            helper = PythonAnalyzerHelper()
+        )
+
+        document1 = Document(
+            symbol_id = PythonSymbolId("test.namespace.hoge", "test_symbol_name"),
+            dependencies = [],
+            content = "test_document_content",
+            succeeded = True
+        )
+        document2 = Document(
+            symbol_id = PythonSymbolId("test.namespace.hoge", "test_symbol_name2"),
+            dependencies = [PythonSymbolId("test.namespace.hoge", "test_symbol_name")],
+            content = "test_document_content2",
+            succeeded = True
+        )
+
+        document_repository.save(document1)
+        document_repository.save(document2)
+
+        result1 = document_repository.get_by_symbol_id(PythonSymbolId("test.namespace.hoge", "test_symbol_name"))
+        if result1:
+            print(result1.get_content())
+        else:
+            print("None")
+        result2 = document_repository.get_by_symbol_id(PythonSymbolId("test.namespace.hoge", "test_symbol_name2"))
+        if result2:
+            print(result2.get_content())
+        else:
+            print("None")
+
+        document_repository.close()
+    
+    debug()


### PR DESCRIPTION
### 概要
ドキュメントの永続化を担うリポジトリ`IDocumentRepository`のSQLiteによる実装を行った。  
また，`Document`オブジェクトについて，(`PackageAnalyzer`を利用せずとも)集約から依存関係まで遡れたら便利であろうと考え，シンボル依存関係を保持させるようにした。

### 変更内容
- `Document`クラスの仕様変更:  
  シンボルの依存関係を保持させる
- リポジトリの返り値を`Document`から`Document|None`に変更:  
  見つからなかった場合をきちんと処理するため
- `SQLiteDocumentRepositoryImpl`の実装:  
- 設定用ファイルやデバッグコードの変更:  
  DIに関わる部分や，リポジトリ・サービス等のデバッグコード修正，.gitignoreで.sqliteファイルを無視，など
- **重要:** LangChainでリクエストを投げるときのトークン数のエラーに対応:  
  本来このissue, ブランチに含めるべきではない変更だが，誤ってコミットに含めてしまい，その取消し方法がわからなかったので，妥協してそのままにしておいた。詳細は「その他情報」へ。

### テスト
自動テストは作成できていないが，[DocumentationService](https://github.com/HLHHS11/Documentation-AI/pull/documentationAI/application/documentation_service.py)のファイル内のデバッグ用コードや，アプリケーション全体の結合テスト等で動作を確認した。
### 影響
### その他情報
#### 変更内容「LangChainでリクエストを投げるときのトークン数のエラーに対応:」について
SQLiteリポジトリのテスト中，何度かドキュメント生成の失敗もみられたため，簡易的な処置として`GPT-3.5 16k context`モデルを使うよう変更していた。こちらは，本来このissue，ブランチで適用すべきではない変更であるが，誤ってコミットに含めてそのままpushしてしまった。本来そこでは`git revert`を行うべきであったが，何も確認せずローカル環境で`git reset --soft HEAD^`を実行してしまった結果，リモートとの差分が生まれ，pullしたらマージが必要となった。その後，きちんと`git revert`を行おうとしたが，どのコミットについてrevertを行うべきかわからず，不用意にコミット履歴を汚染するのも良くないと考え，今回は妥協して変更に含めることにした。
### 関連issue
#12 